### PR TITLE
correct counter's key value

### DIFF
--- a/src/translations/fr.json
+++ b/src/translations/fr.json
@@ -9,7 +9,7 @@
             "day_style": {
                 "values": {
                     "default": "Date",
-                    "compteur": "jours jusqu'à"
+                    "counter": "jours jusqu'à"
                 }
             },
             "layout_picker": {


### PR DESCRIPTION
The key was also translated. Since the right key didn't exist the value form the default language was shown.
<img width="464" alt="image" src="https://github.com/idaho/hassio-trash-card/assets/44422604/298b9600-6027-46f6-921d-9b995dc69774">
