### PR TITLE
Multiple calendar entities

### DIFF
--- a/src/cards/trash-card/container/cards.ts
+++ b/src/cards/trash-card/container/cards.ts
@@ -7,7 +7,6 @@ import '../items/card';
 
 import type { BaseContainerElement } from './BaseContainerElement';
 import type { TrashCardConfig } from '../trash-card-config';
-import type { HassEntity } from 'home-assistant-js-websocket';
 import type { CalendarItem } from '../../../utils/calendarItem';
 import type { HomeAssistant } from '../../../utils/ha';
 
@@ -32,14 +31,11 @@ class Cards extends LitElement implements BaseContainerElement {
   }
 
   public render () {
-    if (!this.config || !this.hass || !this.config.entity) {
+    if (!this.config || !this.hass) {
       return nothing;
     }
 
-    const entityId = this.config.entity;
-    const stateObj = this.hass.states[entityId] as HassEntity | undefined;
-
-    if (!stateObj || !this.items || this.items.length === 0) {
+    if (!this.items || this.items.length === 0) {
       return nothing;
     }
 
@@ -47,7 +43,7 @@ class Cards extends LitElement implements BaseContainerElement {
 
     const cssStyleMap = styleMap({
       // eslint-disable-next-line @typescript-eslint/naming-convention
-      'grid-template-columns': `repeat(${itemsPerRow}, calc(calc(100% - calc(${(itemsPerRow - 1)} * var(--grid-card-gap, 2px))) / ${itemsPerRow}))`
+      'grid-template-columns': `repeat(${itemsPerRow}, calc(calc(100% - calc(${itemsPerRow - 1} * var(--grid-card-gap, 2px))) / ${itemsPerRow}))`
     });
 
     return html`

--- a/src/cards/trash-card/container/chips.ts
+++ b/src/cards/trash-card/container/chips.ts
@@ -8,7 +8,6 @@ import '../items/chip';
 import type { BaseContainerElement } from './BaseContainerElement';
 import type { HomeAssistant } from '../../../utils/ha';
 import type { TrashCardConfig } from '../trash-card-config';
-import type { HassEntity } from 'home-assistant-js-websocket';
 import type { CalendarItem } from '../../../utils/calendarItem';
 
 @customElement(`${TRASH_CARD_NAME}-chips-container`)
@@ -32,14 +31,11 @@ class Chips extends LitElement implements BaseContainerElement {
   }
 
   public render () {
-    if (!this.config || !this.hass || !this.config.entity) {
+    if (!this.config || !this.hass) {
       return nothing;
     }
 
-    const entityId = this.config.entity;
-    const stateObj = this.hass.states[entityId] as HassEntity | undefined;
-
-    if (!stateObj || !this.items || this.items.length === 0) {
+    if (!this.items || this.items.length === 0) {
       return nothing;
     }
 

--- a/src/cards/trash-card/container/icons.ts
+++ b/src/cards/trash-card/container/icons.ts
@@ -7,7 +7,6 @@ import '../items/icon';
 
 import type { BaseContainerElement } from './BaseContainerElement';
 import type { TrashCardConfig } from '../trash-card-config';
-import type { HassEntity } from 'home-assistant-js-websocket';
 import type { CalendarItem } from '../../../utils/calendarItem';
 import type { HomeAssistant } from '../../../utils/ha';
 
@@ -32,14 +31,11 @@ class Icons extends LitElement implements BaseContainerElement {
   }
 
   public render () {
-    if (!this.config || !this.hass || !this.config.entity) {
+    if (!this.config || !this.hass) {
       return nothing;
     }
 
-    const entityId = this.config.entity;
-    const stateObj = this.hass.states[entityId] as HassEntity | undefined;
-
-    if (!stateObj || !this.items || this.items.length === 0) {
+    if (!this.items || this.items.length === 0) {
       return nothing;
     }
 

--- a/src/cards/trash-card/formSchemas.ts
+++ b/src/cards/trash-card/formSchemas.ts
@@ -225,7 +225,15 @@ const getSchema = (customLocalize: ReturnType<typeof setupCustomlocalize>, curre
   ];
 
   const schema: HaFormSchema[] = [
-    { name: 'entity', selector: { entity: { domain: 'calendar' }}},
+    {
+      name: 'entities',
+      selector: {
+        entity: {
+          domain: 'calendar',
+          multiple: true
+        }
+      }
+    },
     {
       type: 'expandable',
       name: '',

--- a/src/cards/trash-card/trash-card-config.ts
+++ b/src/cards/trash-card/trash-card-config.ts
@@ -1,7 +1,6 @@
 import { array, assign, boolean, integer, literal, object, optional, string, union } from 'superstruct';
 import { defaultConfigStruct } from '../../utils/form/defaultConfigStruct';
 
-import type { EntitySharedConfig } from 'lovelace-mushroom/src/shared/config/entity-config';
 import type { ItemSettings } from '../../utils/itemSettings';
 import type { LovelaceCardConfig } from 'lovelace-mushroom/src/ha';
 
@@ -21,10 +20,8 @@ const COLORMODES = [
   'icon'
 ] as const;
 
-type EntityWithOutIcon = Omit<EntitySharedConfig, 'icon'>;
-
- type TrashCardConfig = LovelaceCardConfig &
- EntityWithOutIcon & {
+ type TrashCardConfig = LovelaceCardConfig & {
+   entities: string[];
    pattern?: ItemSettings[];
    next_days?: number;
    items_per_row?: number;
@@ -47,7 +44,7 @@ type EntityWithOutIcon = Omit<EntitySharedConfig, 'icon'>;
 const entityCardConfigStruct = assign(
   defaultConfigStruct,
   object({
-    entity: optional(string()),
+    entities: optional(array(string())),
     name: optional(string()),
     layout: optional(union([ literal('horizontal'), literal('vertical'), literal('default') ])),
     fill_container: optional(boolean()),

--- a/src/cards/trash-card/trash-card.ts
+++ b/src/cards/trash-card/trash-card.ts
@@ -51,7 +51,7 @@ export class TrashCard extends LitElement {
 
     return {
       type: `custom:${TRASH_CARD_NAME}`,
-      entity: entities[0]
+      entities: [ entities[0] ]
     };
   }
 
@@ -113,7 +113,7 @@ export class TrashCard extends LitElement {
     // eslint-disable-next-line @typescript-eslint/no-floating-promises
     getCalendarData(
       this.hass,
-      this.config.entity!,
+      this.config.entities,
       { start, end, dropAfter },
       this.debugger,
       this.config,

--- a/src/cards/trash-card/utils/migration.ts
+++ b/src/cards/trash-card/utils/migration.ts
@@ -9,11 +9,23 @@ type OldConfigWithSetting = TrashCardConfig & Partial<SettingsOfConfig>;
 type LegacayConfig = TrashCardConfig & SettingsOfConfig;
 
 const needsConfigToMigrate = (config: Partial<OldConfigWithSetting>): config is LegacayConfig =>
-  'settings' in config;
+  'settings' in config || 'entity' in config;
 
 const migrateConfig = (config: LegacayConfig) => {
   const pattern: ItemSettings[] = [];
-  const { settings, ...restOfConfiguration } = config;
+  const { settings, entity, ...restOfConfiguration } = config;
+
+  const newConfiguration = {
+    ...restOfConfiguration
+  };
+
+  if ('entity' in config) {
+    newConfiguration.entities = Array.isArray(entity) ? entity : [ entity ];
+  }
+
+  if (!('settings' in config)) {
+    return newConfiguration;
+  }
 
   Object.entries(settings).forEach(([ type, data ]) => {
     pattern.push({
@@ -23,7 +35,7 @@ const migrateConfig = (config: LegacayConfig) => {
   });
 
   return {
-    ...restOfConfiguration,
+    ...newConfiguration,
     pattern
   };
 };

--- a/src/utils/getCalendarData.ts
+++ b/src/utils/getCalendarData.ts
@@ -8,23 +8,41 @@ import type { HomeAssistant } from './ha';
 import type { RawCalendarEvent } from './calendarEvents';
 import type { TrashCardConfig } from '../cards/trash-card/trash-card-config';
 
-const getCalendarData = async (
+const fetchData = async (
   hass: HomeAssistant,
   calendar: string,
+  { start, end }: { start: string; end: string }
+) => {
+  const uri = `calendars/${calendar}?start=${start}&end=${end}`;
+
+  return await hass.callApi<RawCalendarEvent[]>('GET', uri).
+    then(data => data.map(item => ({
+      ...item,
+      entity: calendar
+    })));
+};
+
+const getCalendarData = async (
+  hass: HomeAssistant,
+  calendars: string[],
   { start, end, dropAfter }: { start: string; end: string; dropAfter: boolean },
   debuggerInstance: Debugger,
   config: TrashCardConfig,
   timezoneOffset: string
 ) => {
-  const uri = `calendars/${calendar}?start=${start}&end=${end}`;
+  const rawCalendarEvents: RawCalendarEvent[] = [];
 
-  const rawCalendarEvents = await hass.callApi<RawCalendarEvent[]>('GET', uri);
+  for await (const calendar of calendars) {
+    rawCalendarEvents.push(...await fetchData(hass, calendar, { start, end }));
+  }
 
   debuggerInstance.reset();
   debuggerInstance.log(`timezone`, timezoneOffset);
   debuggerInstance.log(`calendar data`, rawCalendarEvents);
 
   const normalisedEvents = normaliseEvents(rawCalendarEvents, timezoneOffset);
+
+  normalisedEvents.sort((evtA, evtB) => evtA.date.start.getTime() - evtB.date.start.getTime());
 
   const now = new Date();
 


### PR DESCRIPTION
Since now we are able to add use multiple calendar entities.

Instead of the single configuration property `entity` it is now `entries` which contains an array of entities.

Also there is a migration function which converts the single `entity` entry to the `entries` property and adds it as first entry