### PR TITLE
Make chips alignment configurable

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,6 +96,7 @@ All the options are available in the lovelace editor but you can use `yaml` if y
 | `next_days`         | number                                              | 2           | How many times the card will look into the future to find the next event |
 | `day_style`            | `default` or `counter` | `default`   | Option of how the date of an event should be displayed. `default` shows the date in date format and `counter` shows the number of days remaining until the event.       |
 | `card_style`            | `card`, `chip` or `icon` | `card`   | Switch between the events style `Standard card`, `Chip card` or a new `Icon` predefined layout. |
+| `alignment_style`            | `left`, `center`, `right` or `space` | `left`   | Switch between alignments on `Chip card` card_style |
 | `color_mode`            | `background` or `icon` | `background`   | Select whether the color settings should be applied to the background or to the symbol |
 | `refresh_rate`            | integer | 60   | Check for changes in the calendar every x minutes, by default we will check every 60 minutes. Values can be set from 5 to 1440. |
 | `debug`            | boolean | `false`   | Option to enable debug mode to help fixing bugs ;) . |

--- a/src/cards/trash-card/container/chips.ts
+++ b/src/cards/trash-card/container/chips.ts
@@ -39,8 +39,20 @@ class Chips extends LitElement implements BaseContainerElement {
       return nothing;
     }
 
+    let alignment_class = '';
+
+    if (this.config.alignment_style === 'space') {
+      alignment_class = ' align-justify';
+    }
+    if (this.config.alignment_style === 'center') {
+      alignment_class = ' align-center';
+    }
+    if (this.config.alignment_style === 'right') {
+      alignment_class = ' align-end';
+    }
+
     return html`
-    <div class="chip-container">
+    <div class="chip-container${alignment_class}">
       ${this.items.map(item => html`
           <trash-card-item-chip
             .item=${item}

--- a/src/cards/trash-card/formSchemas.ts
+++ b/src/cards/trash-card/formSchemas.ts
@@ -1,4 +1,4 @@
-import { CARDSTYLES, COLORMODES, DAYSTYLES } from './trash-card-config';
+import { CARDSTYLES, ALIGNMENTSTYLES, COLORMODES, DAYSTYLES } from './trash-card-config';
 
 import type { TrashCardConfig } from './trash-card-config';
 import type { HaFormSchema } from '../../utils/form/ha-form';
@@ -237,6 +237,27 @@ const getSchema = (customLocalize: ReturnType<typeof setupCustomlocalize>, curre
               step: 1,
               mode: 'box'
             }}
+          }
+        ]
+      }] as HaFormSchema[] :
+      [],
+    ...currentValues.card_style === 'chip' ?
+      [{
+        type: 'grid',
+        name: '',
+        schema: [
+          {
+            name: 'alignment_style',
+            label: customLocalize(`editor.form.alignment_style.title`),
+            selector: {
+              select: {
+                options: [ ...ALIGNMENTSTYLES ].map(control => ({
+                  value: control,
+                  label: customLocalize(`editor.form.alignment_style.values.${control}`)
+                })),
+                mode: 'dropdown'
+              }
+            }
           }
         ]
       }] as HaFormSchema[] :

--- a/src/cards/trash-card/trash-card-config.ts
+++ b/src/cards/trash-card/trash-card-config.ts
@@ -16,6 +16,13 @@ const CARDSTYLES = [
   'icon'
 ] as const;
 
+const ALIGNMENTSTYLES = [
+  'left',
+  'center',
+  'right',
+  'space'
+] as const;
+
 const COLORMODES = [
   'background',
   'icon'
@@ -35,6 +42,7 @@ const COLORMODES = [
    day_style?: typeof DAYSTYLES[number];
    day_style_format?: string;
    card_style?: typeof CARDSTYLES[number];
+   alignment_style?: typeof ALIGNMENTSTYLES[number];
    color_mode?: typeof COLORMODES[number];
    refresh_rate?: number;
    icon_size?: number;
@@ -63,6 +71,7 @@ const entityCardConfigStruct = assign(
     day_style: optional(union([ literal(DAYSTYLES[0]), literal(DAYSTYLES[1]), literal(DAYSTYLES[2]) ])),
     day_style_format: optional(string()),
     card_style: optional(union([ literal(CARDSTYLES[0]), literal(CARDSTYLES[1]), literal(CARDSTYLES[2]) ])),
+    alignment_style: optional(union([ literal(ALIGNMENTSTYLES[0]), literal(ALIGNMENTSTYLES[1]), literal(ALIGNMENTSTYLES[2]), literal(ALIGNMENTSTYLES[3]) ])),
     color_mode: optional(union([ literal(COLORMODES[0]), literal(COLORMODES[1]) ])),
     debug: optional(boolean()),
     icon_size: optional(integer()),
@@ -85,7 +94,8 @@ export {
   entityCardConfigStruct,
   DAYSTYLES,
   COLORMODES,
-  CARDSTYLES
+  CARDSTYLES,
+  ALIGNMENTSTYLES
 };
 
 export type {

--- a/src/cards/trash-card/trash-card-editor.ts
+++ b/src/cards/trash-card/trash-card-editor.ts
@@ -68,6 +68,7 @@ const configDefaults = {
   day_style: 'default',
   day_style_format: 'yyyy.MM.dd',
   card_style: 'card',
+  alignment_style: 'left',
   color_mode: 'background',
   items_per_row: 1,
   refresh_rate: 60,

--- a/src/translations/da.json
+++ b/src/translations/da.json
@@ -26,6 +26,15 @@
                     "icon": "Ikon"
                 }
             },
+            "alignment_style": {
+                "title": "Justering",
+                "values": {
+                    "left": "venstre",
+                    "center": "centreret",
+                    "right": "ret",
+                    "space": "med afstand"
+                }
+            },
             "color_mode": {
                 "title": "Anvend farve til",
                 "values": {

--- a/src/translations/de.json
+++ b/src/translations/de.json
@@ -26,6 +26,15 @@
                     "icon": "Icon"
                 }
             },
+            "alignment_style": {
+                "title": "Ausrichtung",
+                "values": {
+                    "left": "Linksbündig",
+                    "center": "Mittig",
+                    "right": "Rechtsbündig",
+                    "space": "Mit Abstand"
+                }
+            },
             "color_mode": {
                 "title": "Farbe anwenden auf",
                 "values": {

--- a/src/translations/en.json
+++ b/src/translations/en.json
@@ -26,6 +26,15 @@
                     "icon": "Icon"
                 }
             },
+            "alignment_style": {
+                "title": "Alignment",
+                "values": {
+                    "left": "left",
+                    "center": "centered",
+                    "right": "right",
+                    "space": "spaced"
+                }
+            },
             "color_mode": {
                 "title": "Apply color to",
                 "values": {

--- a/src/translations/fr.json
+++ b/src/translations/fr.json
@@ -26,6 +26,15 @@
                     "icon": "Icône"
                 }
             },
+            "alignment_style": {
+                "title": "Alignement",
+                "values": {
+                    "left": "gauche",
+                    "center": "centré",
+                    "right": "droit",
+                    "space": "espacé"
+                }
+            },
             "color_mode": {
                 "title": "Appliquer une couleur à",
                 "values": {

--- a/src/translations/hu.json
+++ b/src/translations/hu.json
@@ -26,6 +26,15 @@
           "icon": "Ikon"
         }
       },
+      "alignment_style": {
+          "title": "Kiegyenlítés",
+          "values": {
+              "left": "balra",
+              "center": "központosított",
+              "right": "jobbra",
+              "space": "spaced"
+          }
+      },
       "color_mode": {
         "title": "Alkalmazza a színt",
         "values": {

--- a/src/translations/it.json
+++ b/src/translations/it.json
@@ -26,6 +26,15 @@
           "icon": "Icona"
         }
       },
+      "alignment_style": {
+          "title": "Allineamento",
+          "values": {
+              "left": "sinistra",
+              "center": "centrato",
+              "right": "diritto",
+              "space": "distanziato"
+          }
+      },
       "color_mode": {
         "title": "Applicare il colore a",
         "values": {

--- a/src/translations/nl.json
+++ b/src/translations/nl.json
@@ -26,6 +26,15 @@
                     "icon": "Icoon"
                 }
             },
+            "alignment_style": {
+                "title": "Uitlijning",
+                "values": {
+                    "left": "links",
+                    "center": "gecentreerd",
+                    "right": "rechts",
+                    "space": "verdeeld"
+                }
+            },
             "color_mode": {
                 "title": "Kleur aanbrengen op",
                 "values": {

--- a/src/translations/pl.json
+++ b/src/translations/pl.json
@@ -26,6 +26,15 @@
                     "icon": "Symbol"
                 }
             },
+            "alignment_style": {
+                "title": "Wyrównanie",
+                "values": {
+                    "left": "lewy",
+                    "center": "wyśrodkowany",
+                    "right": "prawo",
+                    "space": "rozstawiony"
+                }
+            },
             "color_mode": {
                 "title": "Zastosuj kolor do",
                 "values": {

--- a/src/translations/sk.json
+++ b/src/translations/sk.json
@@ -26,6 +26,15 @@
                     "icon": "Ikona"
                 }
             },
+            "alignment_style": {
+                "title": "Zarovnanie",
+                "values": {
+                    "left": "vľavo",
+                    "center": "vycentrované",
+                    "right": "vpravo",
+                    "space": "rozmiestnené"
+                }
+            },
             "color_mode": {
                 "title": "Použiť farbu na",
                 "values": {


### PR DESCRIPTION
This PR implements #248 and additionally adds space-between and end alignments as well.

This allows for the following alignments (left being the default to avoid breaking changes):
## Left
![image](https://github.com/idaho/hassio-trash-card/assets/12065866/e74a1b14-2e26-4dcc-b8eb-ec6cee44f927)

## Centered
![image](https://github.com/idaho/hassio-trash-card/assets/12065866/c01ec62e-f611-47c5-894f-a79ad0f03f94)

## Right
![image](https://github.com/idaho/hassio-trash-card/assets/12065866/57380a03-01b4-4375-b74a-816bf2f4413e)

## Spaced
![image](https://github.com/idaho/hassio-trash-card/assets/12065866/dd4a7d1c-c81f-4cdb-83e9-6c97866ded5c)

I added all translations, but I only speak German and English, thus the rest is translated by deepl

Lint passes, ReadMe is updated with new parameter

