### PR TITLE
Add end date on card for multiday events

### DIFF
--- a/src/cards/trash-card/items/card.ts
+++ b/src/cards/trash-card/items/card.ts
@@ -21,7 +21,7 @@ class ItemCard extends BaseItemElement {
 
     const { color_mode, hide_time_range, day_style, layout, with_label, day_style_format } = this.config;
 
-    const { label } = item;
+    const { label, date } = item;
 
     const style = {
       ...getColoredStyle(color_mode, item, this.parentElement, this.hass.themes.darkMode)
@@ -29,7 +29,7 @@ class ItemCard extends BaseItemElement {
 
     const content = getDateString(item, hide_time_range ?? false, day_style, day_style_format, this.hass);
 
-    const daysTillToday = daysTill(new Date(), item);
+    const daysTillToday = Math.abs(daysTill(new Date(), date.start));
 
     const cssClasses = {
       today: daysTillToday === 0,

--- a/src/cards/trash-card/items/chip.ts
+++ b/src/cards/trash-card/items/chip.ts
@@ -26,7 +26,7 @@ class ItemChip extends BaseItemElement {
 
     const content = getDateString(item, hide_time_range ?? false, day_style, day_style_format, this.hass);
 
-    const daysTillToday = daysTill(new Date(), item);
+    const daysTillToday = Math.abs(daysTill(new Date(), item.date.start));
 
     const cssClasses = {
       today: daysTillToday === 0,

--- a/src/cards/trash-card/items/icon.ts
+++ b/src/cards/trash-card/items/icon.ts
@@ -26,7 +26,7 @@ class IconCard extends BaseItemElement<{ nextEvent: boolean }> {
       '--trash-card-icon-size': `${this.config.icon_size ?? 40}px`
     };
 
-    const daysTillToday = daysTill(new Date(), item);
+    const daysTillToday = Math.abs(daysTill(new Date(), item.date.start));
 
     const cssClasses = {
       today: daysTillToday === 0,

--- a/src/translations/da.json
+++ b/src/translations/da.json
@@ -114,10 +114,10 @@
             "daysleft_more": "om <DAYS> dage",
             "daysleft_from_till": "om <DAYS> dag\nmellem <START> og <END>",
             "daysleft_more_from_till": "om <DAYS> dage\nmellem <START> og <END>",
-            "daysleftend": "indtil om <DAYS> dag",
-            "daysleftend_more": "indtil om <DAYS> dage",
-            "daysleftend_from_till": "indtil om <DAYS> dag\n klokken <END>",
-            "daysleftend_more_from_till": "indtil om <DAYS> dage\nklokken <END>"
+            "daysleftend": "slutter om <DAYS> dag",
+            "daysleftend_more": "slutter om <DAYS> dage",
+            "daysleftend_from_till": "slutter om <DAYS> dag\n klokken <END>",
+            "daysleftend_more_from_till": "slutter om <DAYS> dage\nklokken <END>"
         }
     }
 }

--- a/src/translations/da.json
+++ b/src/translations/da.json
@@ -116,8 +116,8 @@
             "daysleft_more_from_till": "om <DAYS> dage\nmellem <START> og <END>",
             "daysleftend": "slutter om <DAYS> dag",
             "daysleftend_more": "slutter om <DAYS> dage",
-            "daysleftend_from_till": "slutter om <DAYS> dag\n klokken <END>",
-            "daysleftend_more_from_till": "slutter om <DAYS> dage\nklokken <END>"
+            "daysleftend_till": "slutter om <DAYS> dag\n kl <END>",
+            "daysleftend_more_till": "slutter om <DAYS> dage\nkl <END>"
         }
     }
 }

--- a/src/translations/da.json
+++ b/src/translations/da.json
@@ -113,7 +113,11 @@
             "daysleft": "om <DAYS> dag",
             "daysleft_more": "om <DAYS> dage",
             "daysleft_from_till": "om <DAYS> dag\nmellem <START> og <END>",
-            "daysleft_more_from_till": "om <DAYS> dage\nmellem <START> og <END>"
+            "daysleft_more_from_till": "om <DAYS> dage\nmellem <START> og <END>",
+            "daysleftend": "indtil om <DAYS> dag",
+            "daysleftend_more": "indtil om <DAYS> dage",
+            "daysleftend_from_till": "indtil om <DAYS> dag\n klokken <END>",
+            "daysleftend_more_from_till": "indtil om <DAYS> dage\nklokken <END>"
         }
     }
 }

--- a/src/translations/da.json
+++ b/src/translations/da.json
@@ -116,7 +116,7 @@
             "daysleft_more_from_till": "om <DAYS> dage\nmellem <START> og <END>",
             "daysleftend": "slutter om <DAYS> dag",
             "daysleftend_more": "slutter om <DAYS> dage",
-            "daysleftend_till": "slutter om <DAYS> dag\n kl <END>",
+            "daysleftend_till": "slutter om <DAYS> dag\nkl <END>",
             "daysleftend_more_till": "slutter om <DAYS> dage\nkl <END>"
         }
     }

--- a/src/translations/de.json
+++ b/src/translations/de.json
@@ -116,7 +116,7 @@
             "daysleft_more_from_till": "in <DAYS> Tagen\nvon <START> bis <END>",
             "daysleftend": "endet in <DAYS> Tag",
             "daysleftend_more": "endet in <DAYS> Tagen",
-            "daysleftend_from_till": "endet in <DAYS> Tag\num <END> Uhr",
-            "daysleftend_more_from_till": "endet in <DAYS> Tagen\num <END> Uhr"        }
+            "daysleftend_till": "endet in <DAYS> Tag\num <END> Uhr",
+            "daysleftend_more_till": "endet in <DAYS> Tagen\num <END> Uhr"        }
     }
 }

--- a/src/translations/de.json
+++ b/src/translations/de.json
@@ -113,7 +113,10 @@
             "daysleft": "in <DAYS> Tag",
             "daysleft_more": "in <DAYS> Tagen",
             "daysleft_from_till": "in <DAYS> Tag\nvon <START> bis <END>",
-            "daysleft_more_from_till": "in <DAYS> Tagen\nvon <START> bis <END>"
-        }
+            "daysleft_more_from_till": "in <DAYS> Tagen\nvon <START> bis <END>",
+            "daysleftend": "endet in <DAYS> Tag",
+            "daysleftend_more": "endet in <DAYS> Tagen",
+            "daysleftend_from_till": "endet in <DAYS> Tag\num <END> Uhr",
+            "daysleftend_more_from_till": "endet in <DAYS> Tagen\num <END> Uhr"        }
     }
 }

--- a/src/translations/en.json
+++ b/src/translations/en.json
@@ -132,8 +132,8 @@
             "daysleft_more_from_till": "in <DAYS> days\nbetween <START> and <END>",
             "daysleftend": "ends in <DAYS> day",
             "daysleftend_more": "ends in <DAYS> days",
-            "daysleftend_from_till": "ends in <DAYS> day\nat <END>",
-            "daysleftend_more_from_till": "ends in <DAYS> days\nat <END>"
+            "daysleftend_till": "ends in <DAYS> day\nat <END>",
+            "daysleftend_more_till": "ends in <DAYS> days\nat <END>"
         }
     }
 }

--- a/src/translations/en.json
+++ b/src/translations/en.json
@@ -129,7 +129,11 @@
             "daysleft": "in <DAYS> day",
             "daysleft_more": "in <DAYS> days",
             "daysleft_from_till": "in <DAYS> day\nbetween <START> and <END>",
-            "daysleft_more_from_till": "in <DAYS> days\nbetween <START> and <END>"
+            "daysleft_more_from_till": "in <DAYS> days\nbetween <START> and <END>",
+            "daysleftend": "ends in <DAYS> day",
+            "daysleftend_more": "ends in <DAYS> days",
+            "daysleftend_from_till": "ends in <DAYS> day\nat <END>",
+            "daysleftend_more_from_till": "ends in <DAYS> days\nat <END>"
         }
     }
 }

--- a/src/translations/sv.json
+++ b/src/translations/sv.json
@@ -113,7 +113,10 @@
             "daysleft": "om <DAYS> dag",
             "daysleft_more": "om <DAYS> dagar",
             "daysleft_from_till": "om <DAYS> dag\nmellan <START> och <END>",
-            "daysleft_more_from_till": "om <DAYS> dagar\nmellan <START> och <END>"
-        }
+            "daysleft_more_from_till": "om <DAYS> dagar\nmellan <START> och <END>",
+            "daysleftend": "slutar om <DAYS> dag",
+            "daysleftend_more": "slutar om <DAYS> dagar",
+            "daysleftend_till": "slutar om <DAYS> dag\nkl <END>",
+            "daysleftend_more_till": "slutar om <DAYS> dagar\nkl <END>"        }
     }
 }

--- a/src/utils/daysTill.test.ts
+++ b/src/utils/daysTill.test.ts
@@ -1,17 +1,11 @@
 /* eslint-disable @typescript-eslint/naming-convention */
 import { daysTill } from './daysTill';
 
-import type { CalendarItem } from './calendarItem';
-
 describe('daysTill', (): void => {
   test('2 days till whole day events', async () => {
     const date = new Date(`1970-01-02T00:00:00.000`);
 
-    const item = {
-      date: {
-        start: new Date(`1970-01-04T00:00:00.000`)
-      }
-    } as CalendarItem;
+    const item = new Date(`1970-01-04T00:00:00.000`);
 
     const result = daysTill(date, item);
 
@@ -21,11 +15,7 @@ describe('daysTill', (): void => {
   test('2 days till event at the evening', async () => {
     const date = new Date(`1970-01-02T00:00:00.000`);
 
-    const item = {
-      date: {
-        start: new Date(`1970-01-04T22:00:00.000`)
-      }
-    } as CalendarItem;
+    const item = new Date(`1970-01-04T22:00:00.000`);
 
     const result = daysTill(date, item);
 
@@ -35,11 +25,7 @@ describe('daysTill', (): void => {
   test('2 days till event during leap ear', async () => {
     const date = new Date(`2024-02-28T00:00:00.000`);
 
-    const item = {
-      date: {
-        start: new Date(`2024-03-01T00:00:00.000`)
-      }
-    } as CalendarItem;
+    const item = new Date(`2024-03-01T00:00:00.000`);
 
     const result = daysTill(date, item);
 
@@ -50,11 +36,7 @@ describe('daysTill', (): void => {
     test('from normal to day light saving', async () => {
       const date = new Date(`2024-03-30T00:00:00.000`);
 
-      const item = {
-        date: {
-          start: new Date(`2024-04-01T00:00:00.000`)
-        }
-      } as CalendarItem;
+      const item = new Date(`2024-04-01T00:00:00.000`);
 
       const result = daysTill(date, item);
 
@@ -64,11 +46,7 @@ describe('daysTill', (): void => {
     test('from day light saving to normal', async () => {
       const date = new Date(`2024-10-26T00:00:00.000`);
 
-      const item = {
-        date: {
-          start: new Date(`2024-10-29T00:00:00.000`)
-        }
-      } as CalendarItem;
+      const item = new Date(`2024-10-29T00:00:00.000`);
 
       const result = daysTill(date, item);
 

--- a/src/utils/daysTill.ts
+++ b/src/utils/daysTill.ts
@@ -1,6 +1,4 @@
-import type { CalendarItem } from './calendarItem';
-
-const daysTill = (from: Date, item: CalendarItem) => {
+const daysTill = (from: Date, to: Date) => {
   const oneDay = 24 * 60 * 60 * 1_000;
 
   const todayMorning = new Date(from.getTime());
@@ -9,13 +7,13 @@ const daysTill = (from: Date, item: CalendarItem) => {
   todayMorning.setMinutes(0);
   todayMorning.setSeconds(0);
 
-  const startTimeMorning = new Date(item.date.start.getTime());
+  const toTimeMorning = new Date(to.getTime());
 
-  startTimeMorning.setHours(0);
-  startTimeMorning.setMinutes(0);
-  startTimeMorning.setSeconds(0);
+  toTimeMorning.setHours(0);
+  toTimeMorning.setMinutes(0);
+  toTimeMorning.setSeconds(0);
 
-  return Math.round(Math.abs((todayMorning.getTime() - startTimeMorning.getTime()) / oneDay));
+  return Math.round((toTimeMorning.getTime() - todayMorning.getTime()) / oneDay);
 };
 
 export {

--- a/src/utils/getDateString.ts
+++ b/src/utils/getDateString.ts
@@ -64,9 +64,16 @@ const getDateString = (
   }
 
   if (dayStyle === 'counter') {
-    const daysLeft = daysTill(new Date(), item);
+    const daysToStart = daysTill(new Date(), item.date.start);
 
-    return `${customLocalize(`card.trash.daysleft${daysLeft > 1 ? '_more' : ''}${startTime && !excludeTime ? '_from_till' : ''}`).replace('<DAYS>', `${daysLeft}`).replace('<START>', startTime ?? '').replace('<END>', endTime ?? '')}`;
+    if (daysToStart > 0) {
+      const daysLeft = daysToStart;
+
+      return `${customLocalize(`card.trash.daysleft${daysLeft > 1 ? '_more' : ''}${startTime && !excludeTime ? '_from_till' : ''}`).replace('<DAYS>', `${daysLeft}`).replace('<START>', startTime ?? '').replace('<END>', endTime ?? '')}`;
+    }
+    const daysToEnd = daysTill(new Date(), item.date.end);
+
+    return `${customLocalize(`card.trash.daysleftend${daysToEnd > 1 ? '_more' : ''}${startTime && !excludeTime ? '_from_till' : ''}`).replace('<DAYS>', `${daysToEnd}`).replace('<START>', startTime ?? '').replace('<END>', endTime ?? '')}`;
   }
 
   if (dayStyle === 'weekday') {

--- a/src/utils/getDateString.ts
+++ b/src/utils/getDateString.ts
@@ -73,7 +73,7 @@ const getDateString = (
     }
     const daysToEnd = daysTill(new Date(), item.date.end);
 
-    return `${customLocalize(`card.trash.daysleftend${daysToEnd > 1 ? '_more' : ''}${startTime && !excludeTime ? '_from_till' : ''}`).replace('<DAYS>', `${daysToEnd}`).replace('<START>', startTime ?? '').replace('<END>', endTime ?? '')}`;
+    return `${customLocalize(`card.trash.daysleftend${daysToEnd > 1 ? '_more' : ''}${startTime && !excludeTime ? '_till' : ''}`).replace('<DAYS>', `${daysToEnd}`).replace('<END>', endTime ?? '')}`;
   }
 
   if (dayStyle === 'weekday') {


### PR DESCRIPTION
Fixes issue in #327  with multiday calendar items, that counts up after start date has passed.
